### PR TITLE
bugfix: passing Date proxy to Date constructor

### DIFF
--- a/src/proxy/proxyHandler.ts
+++ b/src/proxy/proxyHandler.ts
@@ -166,7 +166,10 @@ export class CreateProxyHandler {
     }
     if (type === Types.Date) {
       if (typeof v === Types.function) {
-        if ((p as string).indexOf(Methods.set) === 0) {
+        if ((p !== Symbol.toPrimitive) && (
+          (typeof p === 'symbol' && Symbol.keyFor(p)?.indexOf(Methods.set) === 0) ||
+          ((p as string).indexOf(Methods.set) === 0)
+        )) {
           return function (...args: unknown[]) {
             walkParents(state, Actions.set_date, data, pStore, t, p, args);
             return r;

--- a/src/tests/integration/basics.test.ts
+++ b/src/tests/integration/basics.test.ts
@@ -138,6 +138,8 @@ runMultiple("tests all(most) of the basic types", () => {
     const result = produce(myDate, (draft) => {
       draft.a.setSeconds(draft.a.getSeconds() + 1);
       draft.a.setSeconds(draft.a.getSeconds() + 1);
+
+      expect((new Date(draft.a)).toString()).toBe(draft.a.toString()); // compare to the second, since the constructor will drop milliseconds
     });
 
     expect(myDate.a.getTime()).not.toBe(result.a.getTime());


### PR DESCRIPTION
The following throws an exception in the proxy code:
```
const data = { date: new Date() };
produce(data, (draft) => {
  new Date(draft.date);
});
```

The Date constructor calls the method @@toPrimitive on the draft.date proxy, and the proxy code tries to interpret the Symbol as a String.  I think this patch should fix it?

Thanks!