### PR TITLE
Type support for freezing tuples

### DIFF
--- a/src/helpers/freeze.ts
+++ b/src/helpers/freeze.ts
@@ -12,8 +12,10 @@ export type FreezeOnce<T> = T extends Freeze<infer Q> ? Freeze<Q> : Freeze<T>;
 
 export type Freeze<T> = T extends Primitive
   ? T
-  : T extends Array<infer U>
-  ? ReadonlyArray<Freeze<U>>
+  : T extends [infer H] 
+  ? readonly [Freeze<H>]
+  : T extends [infer H, ...infer T] 
+  ?  readonly [Freeze<H>, ...Freeze<T>] 
   : T extends Map<infer K, infer V>
   ? ReadonlyMap<Freeze<K>, Freeze<V>>
   : T extends ReadonlyMap<infer K, infer V>

--- a/src/tests/types/immutability.test-d.ts
+++ b/src/tests/types/immutability.test-d.ts
@@ -17,6 +17,18 @@ describe("results should be staticly immutable", () => {
     // @ts-expect-error nested result is immutable
     m.get("sd").n.n++;
   });
+  test("immutable tuple structure is kept", () => {
+    // If Freeze<X> does not translate to the expected type the entire line would be true as number, resulting in an error. 
+    // If the translation is correct, the line is true as true, giving no error.
+    true as FreezeOnce<number[]> extends readonly number[] ? true : number
+    true as FreezeOnce<(number |  string)[]> extends readonly (number |  string)[] ? true : number
+    true as FreezeOnce<[number, string]> extends readonly [number, string] ? true : number
+    true as FreezeOnce<[number, string, undefined]> extends readonly [number, string, undefined] ? true : number
+
+    true as FreezeOnce<[number, string]> extends readonly [number, [string]] ? number : true
+    true as FreezeOnce<[number, string]> extends readonly [number, string, undefined] ? number : true
+    true as FreezeOnce<(number | string)[]> extends readonly [number, string][] ? number : true
+  })
   test("multiple results are immutable", () => {
     const myObj: FreezeOnce<{ n: number }> = { n: 1 };
     // @ts-expect-error should be immutable


### PR DESCRIPTION
As described in #115, tuples were not correctly handled by the `Freeze<T>` type. This commit is small but fixes the issue.
The tests still run without issue, performance cannot degrade, since it is only in the type system.
A small test was also added to ensure the correctness. With the old approach, some of these typechecks fail.