### PR TITLE
Modern `exports` for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
   "author": "Giuseppe Raso",
   "license": "MIT",
   "main": "./dist/index.js",
+  "exports":{
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "unpkg": "./dist/umd.js",
   "jsdelivr": "./dist/umd.js",
   "type": "module",


### PR DESCRIPTION
I had some problems with using the package for bun. Adding these lines fixed it for me and it seems sensical to me to add it to the main repository. 